### PR TITLE
using fromType.GetGenericArguments() to dynamically generate the requ…

### DIFF
--- a/UI/Editor/ReflectionDrawerUtility.cs
+++ b/UI/Editor/ReflectionDrawerUtility.cs
@@ -259,22 +259,23 @@ namespace Devdog.General.Editors.ReflectionDrawers
             if (fromType.IsGenericType)
             {
                 // Get standard things like string : TODO: Make this dynamic in the future, allowing users to select their own types.
-                implementable = new DerivedTypeInformation()
-                {
-                    types = new Type[]
-                    {
-                        fromType.MakeGenericType(typeof (string)),
-                        fromType.MakeGenericType(typeof (bool)),
-                        fromType.MakeGenericType(typeof (int)),
-                        fromType.MakeGenericType(typeof (float)),
-                        fromType.MakeGenericType(typeof (uint)),
-                        fromType.MakeGenericType(typeof (Vector2)),
-                        fromType.MakeGenericType(typeof (Vector3)),
-                        fromType.MakeGenericType(typeof (Vector4)),
-                        fromType.MakeGenericType(typeof (Quaternion)),
-                        fromType.MakeGenericType(typeof (UnityEngine.Object)),
-                    }
-                };
+                implementable = new DerivedTypeInformation();
+                //{
+                //    types = new Type[10]
+                //    {
+                //        fromType.MakeGenericType(typeof(string)),
+                //        fromType.MakeGenericType(typeof(bool)),
+                //        fromType.MakeGenericType(typeof(int)),
+                //        fromType.MakeGenericType(typeof(float)),
+                //        fromType.MakeGenericType(typeof(uint)),
+                //        fromType.MakeGenericType(typeof(Vector2)),
+                //        fromType.MakeGenericType(typeof(Vector3)),
+                //        fromType.MakeGenericType(typeof(Vector4)),
+                //        fromType.MakeGenericType(typeof(Quaternion)),
+                //        fromType.MakeGenericType(typeof(UnityEngine.Object)),
+                //    }
+                //};
+                implementable.types = TryAddTypes(fromType);
 
                 implementable.content = implementable.types.Select(o => new GUIContent(GetGenericTypeNiceName(o))).ToArray();
             }
@@ -285,6 +286,10 @@ namespace Devdog.General.Editors.ReflectionDrawers
             }
 
             return implementable;
+        }
+        static Type[] TryAddTypes(Type fromType)
+        {
+            return fromType.GetGenericArguments();
         }
 
         public static string GetGenericTypeNiceName(Type type)


### PR DESCRIPTION
Fixed an error when using the general library together with Quest System Pro:
When added "Requires Finished Quests" in QSP Main Editor, it pops out an error:

`ArgumentException: Invalid generic arguments
Parameter name: typeArguments
System.RuntimeType.MakeGenericType (System.Type[] instantiation) (at <567df3e0919241ba98db88bec4c6696f>:0)
Devdog.General.Editors.ReflectionDrawers.ReflectionDrawerUtility.GetDerivedTypesFrom (System.Type fromType, System.Type onlyDerivedFrom) (at Assets/ExternalPlugins/Devdog/General/UI/Editor/ReflectionDrawerUtility.cs:264)
Devdog.General.Editors.ReflectionDrawers.ArrayDrawer.DrawArrayAddButton (UnityEngine.Rect rect) (at Assets/ExternalPlugins/Devdog/General/UI/Editor/ReflectionDrawers/ArrayDrawer.cs:163)
Devdog.General.Editors.ReflectionDrawers.ArrayDrawer.DrawInternal (UnityEngine.Rect rect) (at Assets/ExternalPlugins/Devdog/General/UI/Editor/ReflectionDrawers/ArrayDrawer.cs:99)
Devdog.General.Editors.ReflectionDrawers.DrawerBase.Draw (UnityEngine.Rect& rect) (at Assets/ExternalPlugins/Devdog/General/UI/Editor/ReflectionDrawers/DrawerBase.cs:259)
Devdog.QuestSystemPro.Editors.QuestDrawer.DrawInternal (UnityEngine.Rect rect) (at Assets/ExternalPlugins/Devdog/QuestSystemPro/Scripts/Quests/Editor/QuestDrawer.cs:33)
Devdog.General.Editors.ReflectionDrawers.DrawerBase.Draw (UnityEngine.Rect& rect) (at Assets/ExternalPlugins/Devdog/General/UI/Editor/ReflectionDrawers/DrawerBase.cs:259)
Devdog.General.Editors.BetterUnityEditorBase.OnInspectorGUI () (at Assets/ExternalPlugins/Devdog/General/Serialization/Editor/BetterUnityEditorBase.cs:53)
Devdog.QuestSystemPro.Editors.QuestsEditor.DrawDetail (Devdog.QuestSystemPro.Quest item, System.Int32 index) (at Assets/ExternalPlugins/Devdog/QuestSystemPro/Scripts/Managers/Editor/Quests/QuestsEditor.cs:240)
Devdog.General.Editors.EditorCrudBase`1[T].Draw () (at Assets/ExternalPlugins/Devdog/General/UI/Editor/CrudEditors/EditorCrudBase.cs:87)
Devdog.General.Editors.EmptyEditor.Draw () (at Assets/ExternalPlugins/Devdog/General/UI/Editor/CrudEditors/EmptyEditor.cs:111)
Devdog.QuestSystemPro.Editors.MainEditor.OnGUI () (at Assets/ExternalPlugins/Devdog/QuestSystemPro/Scripts/Managers/Editor/MainEditor.cs:211)
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <567df3e0919241ba98db88bec4c6696f>:0)
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <567df3e0919241ba98db88bec4c6696f>:0)
System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <567df3e0919241ba98db88bec4c6696f>:0)
UnityEditor.HostView.Invoke (System.String methodName, System.Object obj) (at C:/buildslave/unity/build/Editor/Mono/HostView.cs:359)
UnityEditor.HostView.Invoke (System.String methodName) (at C:/buildslave/unity/build/Editor/Mono/HostView.cs:353)
UnityEditor.HostView.InvokeOnGUI (UnityEngine.Rect onGUIPosition, UnityEngine.Rect viewRect) (at C:/buildslave/unity/build/Editor/Mono/HostView.cs:329)
UnityEditor.DockArea.DrawView (UnityEngine.Rect viewRect, UnityEngine.Rect dockAreaRect, System.Boolean floatingWindow, System.Boolean isBottomTab) (at C:/buildslave/unity/build/Editor/Mono/GUI/DockArea.cs:374)
UnityEditor.DockArea.OldOnGUI () (at C:/buildslave/unity/build/Editor/Mono/GUI/DockArea.cs:341)
UnityEngine.UIElements.IMGUIContainer.DoOnGUI (UnityEngine.Event evt, UnityEngine.Matrix4x4 parentTransform, UnityEngine.Rect clippingRect, System.Boolean isComputingLayout, UnityEngine.Rect layoutSize) (at C:/buildslave/unity/build/Modules/UIElements/IMGUIContainer.cs:298)
UnityEngine.UIElements.IMGUIContainer.HandleIMGUIEvent (UnityEngine.Event e, UnityEngine.Matrix4x4 worldTransform, UnityEngine.Rect clippingRect) (at C:/buildslave/unity/build/Modules/UIElements/IMGUIContainer.cs:483)
UnityEngine.UIElements.IMGUIContainer.HandleIMGUIEvent (UnityEngine.Event e) (at C:/buildslave/unity/build/Modules/UIElements/IMGUIContainer.cs:466)
UnityEngine.UIElements.IMGUIContainer.HandleEvent (UnityEngine.UIElements.EventBase evt) (at C:/buildslave/unity/build/Modules/UIElements/IMGUIContainer.cs:447)
UnityEngine.UIElements.MouseCaptureDispatchingStrategy.DispatchEvent (UnityEngine.UIElements.EventBase evt, UnityEngine.UIElements.IPanel panel) (at C:/buildslave/unity/build/Modules/UIElements/Events/MouseCaptureDispatchingStrategy.cs:93)
UnityEngine.UIElements.EventDispatcher.ProcessEvent (UnityEngine.UIElements.EventBase evt, UnityEngine.UIElements.IPanel panel) (at C:/buildslave/unity/build/Modules/UIElements/EventDispatcher.cs:280)
UnityEngine.UIElements.EventDispatcher.Dispatch (UnityEngine.UIElements.EventBase evt, UnityEngine.UIElements.IPanel panel, UnityEngine.UIElements.DispatchMode dispatchMode) (at C:/buildslave/unity/build/Modules/UIElements/EventDispatcher.cs:156)
UnityEngine.UIElements.BaseVisualElementPanel.SendEvent (UnityEngine.UIElements.EventBase e, UnityEngine.UIElements.DispatchMode dispatchMode) (at C:/buildslave/unity/build/Modules/UIElements/Panel.cs:190)
UnityEngine.UIElements.UIElementsUtility.DoDispatch (UnityEngine.UIElements.BaseVisualElementPanel panel) (at C:/buildslave/unity/build/Modules/UIElements/UIElementsUtility.cs:255)
UnityEngine.UIElements.UIElementsUtility.ProcessEvent (System.Int32 instanceID, System.IntPtr nativeEventPtr) (at C:/buildslave/unity/build/Modules/UIElements/UIElementsUtility.cs:78)
UnityEngine.GUIUtility.ProcessEvent (System.Int32 instanceID, System.IntPtr nativeEventPtr) (at C:/buildslave/unity/build/Modules/IMGUI/GUIUtility.cs:179)
`
which is about the fromType.MakeGenericType(typeof(string)), when the fromType requires UnityEngine.Object as generic type.